### PR TITLE
Switch daily report to system-status format

### DIFF
--- a/src/lisp/engine/positions.lisp
+++ b/src/lisp/engine/positions.lisp
@@ -76,6 +76,8 @@
 (defun update-arm-stats (idx won pnl)
   "Update arm statistics after a trade."
   (incf *total-trades*)
+  (when (boundp '*daily-trade-count*)
+    (incf *daily-trade-count*))
   (incf *daily-pnl* pnl)
   (let* ((arm (nth idx *arms*)) (stats (cdr arm))
          (a (ensure-real (car stats))) (b (ensure-real (cdr stats)))

--- a/src/lisp/engine/signals.lisp
+++ b/src/lisp/engine/signals.lisp
@@ -83,7 +83,10 @@
         ((and (< s-prev l-prev) (> s-now l-now))
          (multiple-value-bind (nn-ok conf) (check-neural-confirmation :BUY)
            (if nn-ok
-               (list :BUY conf sl-p tp-p vol)
+               (progn
+                 (setf *last-prediction* "BUY")
+                 (setf *last-confidence* conf)
+                 (list :BUY conf sl-p tp-p vol))
                (progn
                  (format t "[SIGNAL] Filtered BUY (NN: ~,0f%)~%" (* conf 100))
                  nil))))
@@ -92,7 +95,10 @@
         ((and (> s-prev l-prev) (< s-now l-now))
          (multiple-value-bind (nn-ok conf) (check-neural-confirmation :SELL)
            (if nn-ok
-               (list :SELL conf sl-p tp-p vol)
+               (progn
+                 (setf *last-prediction* "SELL")
+                 (setf *last-confidence* conf)
+                 (list :SELL conf sl-p tp-p vol))
                (progn
                  (format t "[SIGNAL] Filtered SELL (NN: ~,0f%)~%" (* conf 100))
                  nil))))


### PR DESCRIPTION
### Motivation

- Replace the old narrative-heavy daily report with a concise, machine-friendly system status summary so values are always displayed and useful for monitoring. 

### Description

- Rework `send-daily-tribal-narrative` in `src/lisp/core/narrative.lisp` to emit system metrics (PnL, wins/losses, trades, system state, last signal and confidence, regimes, tribe/swarm consensus, flood/risk details, equity/peak) instead of narrative quotes. 
- Add helpers `safe-symbol-value`, `format-value`, and `format-percent` to safely read potentially-unbound globals and to consistently format numbers, symbols, and percentage values. 
- Use explicit qualified global symbol lookups (e.g. `'swimmy.globals::*daily-pnl*`) to avoid defaulting to unhelpful defaults and ensure values show when available. 
- Preserve existing embed color selection logic for report severity based on `*danger-level*`.

### Testing

- Ran `pytest`, which failed during collection with 9 errors due to missing dependency `zmq` (`ModuleNotFoundError: No module named 'zmq'`).
- Ran `flake8`, which is not available in the environment (command not found). 
- No unit-test failures related to the changed Lisp file itself were observed because the Python test-suite errors prevented full test execution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e8e212dfc8332b8baa26d4c5e91cc)