### PR TITLE
feat(tribe-P4/P5): reliability (crash-loop/heap/mem) + persistence corruption-resistance

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,3 +18,4 @@
 *.service text eol=lf
 *.timer   text eol=lf
 *.env     text eol=lf
+*.py      text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,13 @@
 # payloads and Discord/log output. Force LF regardless of core.autocrlf.
 *.lisp text eol=lf
 *.asd  text eol=lf
+
+# P4 (Thread B / reliability): files that are executed/parsed on the Linux ops
+# box MUST check out as LF regardless of core.autocrlf. A stray CR turns a
+# shell shebang into `#!/usr/bin/env bash\r` (bad interpreter) and injects
+# `\r` into systemd unit directives, silently breaking the very reliability
+# machinery P4 installs.
+*.sh      text eol=lf
+*.service text eol=lf
+*.timer   text eol=lf
+*.env     text eol=lf

--- a/config/heap.env
+++ b/config/heap.env
@@ -1,0 +1,19 @@
+# Swimmy SBCL heap allocation — single source of truth (P4 / Thread B).
+# ---------------------------------------------------------------------------
+# Canonical template. Install to /etc/swimmy/heap.env on the ops box with:
+#     sudo tools/ops/install_heap_env.sh
+# Both swimmy-brain.service and swimmy-school.service load it last via
+#     EnvironmentFile=-/etc/swimmy/heap.env
+# so this file wins over the in-unit defaults and over .env.
+#
+# The two heaps use DELIBERATELY SEPARATE variable names. Previously both
+# daemons read SWIMMY_SBCL_DYNAMIC_SPACE_MB, so any shared default or bulk
+# edit collapsed both heaps to one value. Keep them independent.
+#
+#   brain  = 3072 MB  (inference / motor loop; leaner working set)
+#   school = 4096 MB  (evolution + graveyard cache; heavier, per STATE.md:2166)
+#
+# The one-off tool scripts (tools/*.sh, finalize_rank_report, system_audit)
+# still use SWIMMY_SBCL_DYNAMIC_SPACE_MB and are intentionally NOT affected.
+SWIMMY_BRAIN_HEAP_MB=3072
+SWIMMY_SCHOOL_HEAP_MB=4096

--- a/doc/knowledge/expert_panel_20260213.md
+++ b/doc/knowledge/expert_panel_20260213.md
@@ -16,6 +16,7 @@
 - Data Keeper は大きな固定バッファを常時確保する設計（`tools/data_keeper.py:60`, `tools/data_keeper.py:61`）。
 - さらに起動時に全TFを eager load しており、メモリ・起動時間を前払いで消費する（`tools/data_keeper.py:188`, `tools/data_keeper.py:193`）。
 - `swimmy-data-keeper.service` は `StartLimitIntervalSec` を `[Service]` に置いており無効。実際に systemd が Unknown key を出している。安全装置が“あるつもり”になっている（`systemd/swimmy-data-keeper.service:13`）。
+  > [!NOTE] **訂正 (2026-07-12 / P4, stale)**: この指摘は解消済。現行 `systemd/swimmy-data-keeper.service:4-5` は `StartLimitIntervalSec=300` / `StartLimitBurst=5` を正しく `[Unit]` に置いており実害なし。P4 で cgroup `MemoryMax=3G` も追加（Taleb の「上限がない」指摘に対応）。
 
 ### Graham
 「複雑さの借金を、CPUとRAMで返済している。これはスケールしない。」
@@ -38,6 +39,7 @@
 「設定責務が分裂している。設定値が宣言されても、実行経路で使われない。」
 - `swimmy-brain.service` は `SWIMMY_SBCL_DYNAMIC_SPACE_MB` を定義しているが（`systemd/swimmy-brain.service:17`）、実際の起動スクリプトは 4096 固定で無視している（`run.sh:64`）。
 - “設定があるのに効かない”状態は運用事故を量産する。これは設計の失敗。
+  > [!NOTE] **訂正 (2026-07-12 / P4, stale)**: 「4096 固定で無視」は誤り。`run.sh` は当時から env を尊重していた（現行 `run.sh:69` は `${SWIMMY_BRAIN_HEAP_MB:-${SWIMMY_SBCL_DYNAMIC_SPACE_MB:-6144}}`）。P4 でヒープを `/etc/swimmy/heap.env` に一元化し brain=3072 / school=4096、変数名を daemon 別に分離した。Fowler の「設定が実行経路で使われない」問題は解消（unit が heap.env を最後に読む単一正本）。
 
 ### Hickey
 「Simple made easy を逆行している。巨大な可変構造をぐるぐる回している。」
@@ -85,6 +87,6 @@
 2. `phase-7-wisdom-update` を毎サイクル実行から間隔実行へ変更（`src/lisp/school/school-connector.lisp:219`）。
 3. `phase-8-weekly-prune` の skip 条件（incubator backlog）を緩和し、hard-cap が効く状態を担保（`src/lisp/school/school-connector.lisp:116`, `src/lisp/school/school-pruning.lisp:30`）。
 4. Data Keeper の `MAX_CANDLES_PER_SYMBOL`/`MAX_TICKS_PER_SYMBOL` を env 化し、起動時は M1 を lazy-load（`tools/data_keeper.py:60`, `tools/data_keeper.py:61`, `tools/data_keeper.py:193`）。
-5. `run.sh` の `--dynamic-space-size` を env 参照へ統一し、`swimmy-brain.service` と整合（`run.sh:64`, `systemd/swimmy-brain.service:17`）。
-6. `systemd/swimmy-data-keeper.service` の `StartLimit*` を `[Unit]` へ移して検証スクリプト追加（`systemd/swimmy-data-keeper.service:13`）。
+5. ~~`run.sh` の `--dynamic-space-size` を env 参照へ統一し、`swimmy-brain.service` と整合~~ **✅ 済 (P4)**: `run.sh` は元々 env 尊重。P4 で `/etc/swimmy/heap.env` 一元化（brain 3072 / school 4096、変数名分離）。→ `doc/knowledge/p4_reliability_ops_20260712.md`。
+6. ~~`systemd/swimmy-data-keeper.service` の `StartLimit*` を `[Unit]` へ移して検証スクリプト追加~~ **✅ 済**: 現行は `[Unit]` に正しく配置。P4 で `MemoryMax=3G` 追加＋`tests/systemd_reliability_test.sh` で回帰防止。
 7. docsの実値整合を修正（M1保持上限、prune頻度）: `docs/llm/ARCHITECTURE.md:75`, `docs/llm/STATE.md:71`, `doc/owners_guide.md:157`。

--- a/doc/knowledge/p4_reliability_ops_20260712.md
+++ b/doc/knowledge/p4_reliability_ops_20260712.md
@@ -1,0 +1,94 @@
+# 🛡️ P4 信頼性（クラッシュループ／メモリ／ヒープ）— 実装到達点と deploy 手順
+
+**作成日:** 2026-07-12 JST
+**スレッド:** B（P4/P5）／`rebuild_design_fable_P1-P7_20260703.md` §3 P4
+**ステータス:** 実装済（オフライン・段階コミット）。deploy はオーナーの WSL(Ubuntu, user=swimmy) 上で実施。
+**制約:** ライブ発注なし・オフライン検証のみ・gate floor 不変。
+
+> [!IMPORTANT]
+> 本 P4 の変更は **systemd ユニット／shell／env の設定のみ**。Rust Guardian の
+> ライブ発注・清算セマンティクスは**一切変更していない**（下記 §4 の理由）。
+
+---
+
+## 1. クラッシュループ是正（毒データ無限再起動の根治）
+
+| ユニット | Before | After |
+|---|---|---|
+| swimmy-brain | `Restart=always` / 10s / **StartLimit 無し** | `Restart=on-failure` / **30s** / `StartLimitIntervalSec=600` + `StartLimitBurst=5` / `OnFailure=swimmy-alert@%n.service` |
+| swimmy-school | `Restart=always` / 10s / **StartLimit 無し** | 同上 |
+
+- school-daemon は「Let It Crash」（`src/lisp/school/school-daemon.lisp:10-17` が未捕捉例外で `exit 1`）。`always`＋無制限では毒データを無限再起動で不死化していた。
+- **600秒内に5回失敗すると unit は `failed` に入り恒久停止**。`OnFailure` が alert を1回だけ発火。
+- restore_legend_61 の毎起動 ExecStartPre は **P2c で stamp 方式化済**（`tools/restore_legend_61.lisp`：source 署名一致時は full load をスキップし exit 0）。P4 での追加変更は不要。
+
+## 2. OnFailure alert（恒久停止の可視化）
+
+- `systemd/swimmy-alert@.service`（oneshot テンプレート）＋ `tools/ops/alert_on_failure.sh`。
+- 失敗した unit 名を `%i` で受け取り、**durable ログ（logs/alert.log）を必ず記録**。`SWIMMY_DISCORD_ALERTS` が設定済のときのみ Discord 通知（best-effort）。
+- alerter 自身は `Restart=`／`OnFailure=` を持たず、常に `exit 0` ＝ **fail-loop しない**。
+
+## 3. ヒープ／メモリ配分
+
+- **`/etc/swimmy/heap.env` に一元化**（`config/heap.env` が repo 正本）。両 unit が `EnvironmentFile=-/etc/swimmy/heap.env` を**最後に**読み、単一の正本として in-unit 既定・`.env` を上書き。
+- **変数名を daemon 別に分離**：`SWIMMY_BRAIN_HEAP_MB=3072` / `SWIMMY_SCHOOL_HEAP_MB=4096`。旧 `SWIMMY_SBCL_DYNAMIC_SPACE_MB` の一括置換事故を防止。
+- `run.sh`（brain）は `SWIMMY_BRAIN_HEAP_MB` → 旧共有変数 → 6144（bare dev 既定）の順で解決。native Windows の `scripts/windows/run.ps1` も同順で parity。
+- 単発ツール（`tools/*.sh`、`finalize_rank_report`、`system_audit`）は従来どおり `SWIMMY_SBCL_DYNAMIC_SPACE_MB` を使用（**意図的に非改変**）。
+- **swimmy-data-keeper に `MemoryMax=3G`**（cgroup）。暴走 read/merge が brain/school の heap を枯渇させるのを防ぐ。OOM 時は当該 unit のみ kill→`Restart=always` が再起動。
+
+## 4. Guardian degraded 運転（brain 恒久停止時）— 既存実装で成立
+
+**結論：P4a の StartLimit で brain が恒久停止すると、Guardian の既存 brain-disconnect ゲートが degraded 運転を成立させる。Rust の追加変更は不要。**
+
+連鎖：
+
+1. brain が 600s 内 5回失敗 → systemd が `failed`（恒久停止）。
+2. `OnFailure` → alert 1回。
+3. Guardian は brain 無音を検知（`should_trigger_brain_timeout` `guardian/src/main.rs:882`、既定 timeout 300s `:1008`）し `brain_connected=false` `:1170` にする。
+4. **新規エントリ全停止**：risk gate `check_order` が `if !self.brain_connected { return Err(VetoReason::BrainTimeout) }` `guardian/src/main.rs:802-803` で BUY/SELL を veto。
+5. **既存ポジは管理継続**：Guardian の主ループは市場データ処理・PnL 追跡・週末クローズ・SL/TP 管理を継続（新規のみ停止）。
+6. **revival loop 防止**：Guardian の auto-revival は 300s 内 2 death で halt `guardian/src/main.rs:1106-1107,1208`。brain 側 StartLimit(5/600s) と両立（Guardian が先に諦める）。`failed` 状態の brain への `systemctl restart` は systemd が rate-limit で拒否 → 恒久停止が保たれる。
+
+### ⚠️ オーナー判断事項（本 P4 では未変更）
+brain タイムアウト時、現行の dead-man switch は短TF ポジを **emergency close**（`CLOSE_SHORT_TF`＋`CANCEL_ALL` `guardian/src/main.rs:1359-1373`、D1+ は保護）する。
+- 設計の「既存ポジ**保護**のみ」を「短TFは清算して縮小・D1+のみ保持」と読むなら**現行のままで整合**。
+- 「全ポジを保持して SL/TP 管理のみ」に変えるなら **ライブ清算セマンティクスの変更**＝ hard-to-reverse・要オフライン外検証のため、**オーナーの明示判断が必要**。本 P4 では現行挙動を保持した。
+
+---
+
+## 5. Deploy 手順（WSL Ubuntu / user=swimmy）
+
+```bash
+# 0. リポジトリ最新化（このブランチを WSL 側へ）
+cd /home/swimmy/swimmy
+
+# 1. ヒープ正本を設置
+sudo tools/ops/install_heap_env.sh
+#    -> /etc/swimmy/heap.env (BRAIN=3072 / SCHOOL=4096)
+
+# 2. unit を配置（system 正本）
+sudo cp systemd/swimmy-brain.service systemd/swimmy-school.service \
+        systemd/swimmy-data-keeper.service systemd/swimmy-alert@.service \
+        /etc/systemd/system/
+sudo systemctl daemon-reload
+
+# 3. 再起動
+sudo systemctl restart swimmy-brain swimmy-school swimmy-data-keeper
+
+# 4. 検証
+systemctl show swimmy-brain  -p Restart,RestartUSec,StartLimitIntervalUSec,StartLimitBurst
+systemctl show swimmy-school -p Restart,RestartUSec,StartLimitIntervalUSec,StartLimitBurst
+systemctl cat  swimmy-brain | grep -E 'BRAIN_HEAP|heap.env|OnFailure'
+systemctl show swimmy-data-keeper -p MemoryMax
+#    OnFailure の疎通は手動テスト:
+#    sudo systemctl start swimmy-alert@swimmy-brain.service ; tail logs/alert.log
+```
+
+期待値：`Restart=on-failure` / `RestartUSec=30s` / `StartLimitIntervalUSec=10min` / `StartLimitBurst=5`、brain heap=3072・school heap=4096、data-keeper `MemoryMax=3221225472`(3G)。
+
+---
+
+## 6. 回帰防止
+
+- `tests/systemd_reliability_test.sh`：school/brain の on-failure＋StartLimit＋OnFailure、heap.env の変数分離、data-keeper MemoryMax、alerter が fail-loop 防止（Restart 無し）を assert。
+- `.gitattributes`：`*.sh`/`*.service`/`*.timer`/`*.env` を `eol=lf` にピン（CR 混入で shebang/unit ディレクティブが壊れるのを防止）。

--- a/doc/knowledge/p5_persistence_ops_20260712.md
+++ b/doc/knowledge/p5_persistence_ops_20260712.md
@@ -1,0 +1,66 @@
+# 🗄️ P5 永続化の破損耐性 — 実装到達点と deploy 手順
+
+**作成日:** 2026-07-12 JST
+**スレッド:** B（P4/P5）／`rebuild_design_fable_P1-P7_20260703.md` §3 P5
+**ステータス:** 実装済（オフライン・段階コミット）。deploy はオーナーの WSL(Ubuntu, user=swimmy) 上で実施。
+**制約:** ライブ発注なし・オフライン検証のみ・gate floor 不変。
+**関連:** [`p4_reliability_ops_20260712.md`](p4_reliability_ops_20260712.md)
+
+---
+
+## 1. 実装マップ（設計 P5 との対応）
+
+| # | 設計項目 | 実装 |
+|---|---|---|
+| 1 | WAL / synchronous=NORMAL / busy_timeout | **既存で成立**（`src/lisp/core/sqlite-manager.lisp:32-34`、`get-db-connection` で毎接続設定）。P5 で追加変更なし。 |
+| 2 | graveyard を BEGIN IMMEDIATE…COMMIT | `with-immediate-transaction`（sqlite-manager.lisp）を新設し、`record-graveyard-pattern`（school-cemetery.lisp）の rank flip + upsert を包む。RESERVED ロックを先取り＝ brain/school 競合での SQLITE_BUSY 敗北を排除。 |
+| 3 | data_sexp に sha256 checksum ＋サイズ上限 | `sha256-hex`（ironclad, UTF-8）＋列 `data_sexp_sha256`（migration）。`upsert-strategy` が checksum 保存。`*max-data-sexp-length*`=256KB 超過は `:OVERSIZE:<len>` sentinel に差替（metric 列は保持、poison blob を DB に入れない）。 |
+| 4 | tmp 名一意化（pid+epoch） | `save-strategy`（persistence.lisp）の temp-path を `<name>.<pid-proctoken>-<counter>.tmp` に。並行 writer の tmp 衝突を排除。 |
+| 5 | 欠損検知監査（read-only 日次） | `tools/persistence_audit.py`（read-only）。graveyard 単調非減少 invariant（高水位 stamp）、checksum 整合、hash INVALID 比率、:CORRUPT 数、oversize 数、library ファイル数 vs SQL 行数突合。`swimmy-persistence-audit.service`/`.timer`（日次）。違反時 exit 1 → `OnFailure` alert。 |
+| 6 | 破損行は削除せず quarantine | `cemetery-audit-db` が safe-read 不能行を `hash=':INVALID', rank=':CORRUPT'` に（削除しない）。`:CORRUPT` は active/breeding allow-list（B/A/S/LEGEND）外で自然除外、blob も `%deserialize-strategy-row` で drop。`%parse-rank-safe` は `:CORRUPT` を安全に parse。 |
+
+## 2. 設計の「未確認」への回答
+
+- **temp-path 同一FS（rename アトミック性の前提）**: ✅ **解決**。`save-strategy` の temp-path は `(merge-pathnames "<name>.<token>.tmp" path)` で、`path`（＝ `data/library/<rank>/<name>.lisp`）の**同一ディレクトリ**に生成される。同一 FS のため `rename-file` はアトミック。
+
+## 3. 破損検知の設計思想
+
+safe-read（`safe-read-sexp`）は破損を握り潰して nil を返す＝**静かな消失**が P5 の根本課題。対策は「握り潰しをやめる」ではなく「**別レイヤで気付く**」:
+- 書込時に **checksum を刻む**（sha256）。
+- 監査が **checksum 不整合・graveyard 減少・INVALID 比率**を read-only で検出。
+- 破損行は **削除せず :CORRUPT へ隔離**（フォレンジック保全＋ active から除外）。
+- graveyard の**単調非減少**を高水位 stamp で強制（append-only の失敗記録が縮んだら＝行喪失の確たる兆候→ HARD 違反）。
+
+## 4. 検証（オフライン）
+
+native-Windows は cl-sqlite の DLL 未ロードで full-system ロード不可のため、検証を分離:
+- `sha256-hex`：SBCL+ironclad で NIST `"abc"` ベクタ一致・unicode 耐性を確認。
+- SQL セマンティクス：`tests/p5_persistence_sql_test.py`（同一 SQLite エンジン, Python）で migration 冪等・BEGIN IMMEDIATE commit/rollback・checksum roundtrip/mismatch・oversize sentinel・:CORRUPT 除外/非削除・単調 invariant を検証（13/13 pass）。
+- 監査 end-to-end：`tests/p5_audit_test.py`（合成 DB）で全 metric＋graveyard 行削除→ invariant 違反(exit 1) を検証。
+- Lisp 構造健全性：編集5ファイルの paren-balance 確認。
+- ⏳ **WSL ホストで要実行**：full `ql:quickload :swimmy` コンパイル通過確認（DLL がある Linux 側でのみ可能）。deploy 前に `sbcl --script` で `:swimmy` ロード→ `run-persistence-audit` 相当のスモークを推奨。
+
+## 5. Deploy 手順（WSL Ubuntu / user=swimmy）
+
+```bash
+cd /home/swimmy/swimmy
+# 1. 監査 timer/service を配置
+sudo cp systemd/swimmy-persistence-audit.service systemd/swimmy-persistence-audit.timer \
+        systemd/swimmy-alert@.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now swimmy-persistence-audit.timer
+
+# 2. 既存 DB のスキーマ migration は school 側の init-db が起動時に冪等適用
+#    （ALTER TABLE ADD COLUMN data_sexp_sha256）。強制する場合は school 再起動。
+sudo systemctl restart swimmy-school
+
+# 3. 監査を手動実行（read-only）
+.venv/bin/python3 tools/persistence_audit.py
+#    -> logs/persistence_audit.log に JSON、graveyard 高水位 stamp を
+#       data/memory/.graveyard_hwm に作成。
+
+# 4. cemetery-audit-db を一度回して既存破損行を :CORRUPT へ隔離（school 内から）
+#    （通常運転で hash IS NULL 行を検出時に自動適用）
+```
+
+**注意**: 初回監査は既存 DB の checksum 未設定行を `checksum_unchecked` として報告する（違反ではない）。upsert で再保存されるにつれ 0 に収束する。`data_sexp_sha256` が既存行に無い間は checksum 検査はスキップされる（列が無ければ検査自体を飛ばす）。

--- a/run.sh
+++ b/run.sh
@@ -65,7 +65,10 @@ if [ "$BOOT_TEMP" -eq 1 ]; then
 fi
 
 # Start Swimmy with logging
-# Allow runtime tuning from .env without editing this script again.
-SBCL_DYNAMIC_SPACE_MB="${SWIMMY_SBCL_DYNAMIC_SPACE_MB:-6144}"
+# Allow runtime tuning without editing this script again.
+# P4: prefer the brain-specific heap var (from /etc/swimmy/heap.env, default
+# 3072 under systemd). Fall back to the legacy shared var, then to 6144 for
+# bare dev/native runs with no heap.env present.
+SBCL_DYNAMIC_SPACE_MB="${SWIMMY_BRAIN_HEAP_MB:-${SWIMMY_SBCL_DYNAMIC_SPACE_MB:-6144}}"
 echo "[$(date)] Starting Swimmy Ver 41.5..."
 sbcl --dynamic-space-size "$SBCL_DYNAMIC_SPACE_MB" --noinform --load "$BOOT_FILE" 2>&1 | tee logs/swimmy.log

--- a/scripts/windows/run.ps1
+++ b/scripts/windows/run.ps1
@@ -70,7 +70,11 @@ function Start-Brain {
         $bootFile = $bootTemp.FullName
     }
 
-    $heap = if ($env:SWIMMY_SBCL_DYNAMIC_SPACE_MB) { $env:SWIMMY_SBCL_DYNAMIC_SPACE_MB } else { '6144' }
+    # P4: prefer the brain-specific heap var (parity with run.sh), fall back to
+    # the legacy shared var, then 6144 for bare native runs.
+    $heap = if ($env:SWIMMY_BRAIN_HEAP_MB) { $env:SWIMMY_BRAIN_HEAP_MB } `
+            elseif ($env:SWIMMY_SBCL_DYNAMIC_SPACE_MB) { $env:SWIMMY_SBCL_DYNAMIC_SPACE_MB } `
+            else { '6144' }
     $sbcl = Resolve-Sbcl
     Write-Host "[$(Get-Date)] Starting Swimmy Ver 41.5 (heap ${heap}MB) via $sbcl..."
     try {

--- a/src/lisp/core/persistence.lisp
+++ b/src/lisp/core/persistence.lisp
@@ -66,14 +66,33 @@
     (ensure-directory (merge-pathnames (format nil "~a/" dir) *library-path*)))
   (format t "[LIB] 📚 Library initialized at ~a~%" *library-path*))
 
+(defvar *save-proc-token*
+  (format nil "~a-~a"
+          (or (ignore-errors (sb-unix:unix-getpid)) (random 1000000))
+          (get-universal-time))
+  "Per-process token (pid + process-start time) that discriminates the atomic
+   .tmp files of concurrent writers. Two processes (brain vs school) get
+   distinct tokens; a per-call counter distinguishes writes within a process.")
+
+(defvar *save-tmp-counter* 0
+  "Monotonic per-process counter appended to atomic .tmp names.")
+
 (defun save-strategy (strategy-obj)
   "Save a strategy object to a file ATOMICALLY (Expert Panel 2).
-   Writes to .tmp first, then renames to prevent corruption."
-  
+   Writes to a unique .tmp first, then renames to prevent corruption.
+   P5: the .tmp name is uniquified with a per-process token + counter so two
+   daemons saving the same strategy concurrently never write the same temp file
+   (which would let one truncated write clobber the other before rename)."
+
   (let* ((name (slot-value strategy-obj 'swimmy.school::name))
          (rank (strategy-storage-rank strategy-obj))
          (path (get-strategy-path name rank))
-         (temp-path (merge-pathnames (format nil "~a.tmp" (pathname-name path)) path)))
+         (temp-path (merge-pathnames
+                     (format nil "~a.~a-~a.tmp"
+                             (pathname-name path)
+                             *save-proc-token*
+                             (incf *save-tmp-counter*))
+                     path)))
     
     (ensure-directories-exist path)
 

--- a/src/lisp/core/sqlite-manager.lisp
+++ b/src/lisp/core/sqlite-manager.lisp
@@ -62,3 +62,40 @@
   `(let ((conn (get-db-connection)))
      (sqlite:with-transaction conn
        ,@body)))
+
+;;; ---------------------------------------------------------------------------
+;;; P5 (Thread B / persistence hardening)
+;;; ---------------------------------------------------------------------------
+
+(defmacro with-immediate-transaction (&body body)
+  "Like WITH-TRANSACTION but issues BEGIN IMMEDIATE, taking the RESERVED write
+   lock up front. cl-sqlite's WITH-TRANSACTION uses a DEFERRED begin, so a
+   read-then-write (e.g. graveyard upsert) can start a shared transaction and
+   then hit SQLITE_BUSY when it tries to upgrade to a write while the other
+   daemon (brain vs school) holds the lock — losing the write. BEGIN IMMEDIATE
+   serializes writers cleanly. Rolls back on any non-local exit."
+  (let ((conn (gensym "CONN")) (ok (gensym "OK")))
+    `(let ((,conn (get-db-connection)) (,ok nil))
+       (sqlite:execute-non-query ,conn "BEGIN IMMEDIATE")
+       (unwind-protect
+            (multiple-value-prog1 (progn ,@body)
+              (sqlite:execute-non-query ,conn "COMMIT")
+              (setf ,ok t))
+         (unless ,ok
+           (ignore-errors (sqlite:execute-non-query ,conn "ROLLBACK")))))))
+
+(defparameter *max-data-sexp-length* 262144
+  "Hard upper bound (chars) on a strategy's serialized data_sexp blob. A healthy
+   strategy struct serializes to a few KB; anything past 256KB is treated as
+   corruption/pathology and its blob is NOT persisted (metrics still are), so a
+   poison blob can't propagate and bloat the DB. Tunable.")
+
+(defun sha256-hex (string)
+  "Lowercase 64-char hex SHA-256 of STRING (UTF-8). Integrity checksum for the
+   data_sexp column: computed at write, re-verified by the persistence audit so
+   silent bit-rot/truncation is caught instead of being swallowed by safe-read.
+   ironclad is already a hard dependency (swimmy.asd)."
+  (when (stringp string)
+    (ironclad:byte-array-to-hex-string
+     (ironclad:digest-sequence
+      :sha256 (sb-ext:string-to-octets string :external-format :utf-8)))))

--- a/src/lisp/packages.lisp
+++ b/src/lisp/packages.lisp
@@ -328,6 +328,10 @@
    #:execute-single
    #:with-transaction
    #:close-db-connection
+   ;; P5: persistence hardening
+   #:with-immediate-transaction
+   #:sha256-hex
+   #:*max-data-sexp-length*
    ))
 
 

--- a/src/lisp/school/school-cemetery.lisp
+++ b/src/lisp/school/school-cemetery.lisp
@@ -54,7 +54,15 @@
                    (if (and strat (strategy-p strat))
                        (let ((hash (calculate-strategy-hash strat)))
                          (execute-non-query "UPDATE strategies SET hash = ? WHERE name = ?" hash name))
-                       (execute-non-query "UPDATE strategies SET hash = ':INVALID' WHERE name = ?" name)))))
+                       ;; P5 (Thread B): the blob did not parse to a strategy =
+                       ;; corruption. QUARANTINE (rank=:CORRUPT), never delete, so
+                       ;; the row survives for forensics and is excluded from every
+                       ;; active/breeding allow-list (which enumerate B/A/S/LEGEND).
+                       (progn
+                         (format t "[CEMETERY] ☣️ QUARANTINE: ~a data_sexp unreadable -> rank=:CORRUPT~%" name)
+                         (execute-non-query
+                          "UPDATE strategies SET hash = ':INVALID', rank = ':CORRUPT' WHERE name = ?"
+                          name))))))
            (error (e) 
              (format t "[CEMETERY] ⚠️ Batch failed: ~a~%" e)
              (return)))
@@ -65,9 +73,20 @@
     total-processed))
 
 (defun record-graveyard-pattern (strat)
-  "Explicitly add a strategy to the graveyard and save its hash."
+  "Explicitly add a strategy to the graveyard and save its hash.
+   P5: the rank flip + upsert run under BEGIN IMMEDIATE so the graveyard write
+   is atomic and never loses to a concurrent brain/school writer (SQLITE_BUSY).
+   The graveyard is the append-only failure record whose monotonic growth the
+   persistence audit relies on, so a dropped write here is exactly what we must
+   prevent."
   (setf (strategy-rank strat) :GRAVEYARD)
   (unless (strategy-hash strat)
     (setf (strategy-hash strat) (calculate-strategy-hash strat)))
-  (upsert-strategy strat)
+  (handler-case
+      (with-immediate-transaction
+        (upsert-strategy strat))
+    (error (e)
+      (format t "[CEMETERY] ⚠️ Graveyard write failed for ~a: ~a~%"
+              (strategy-name strat) e)
+      (return-from record-graveyard-pattern nil)))
   (format t "[CEMETERY] 🪦 Recorded pattern ~a to SQL Graveyard.~%" (strategy-name strat)))

--- a/src/lisp/school/school-db.lisp
+++ b/src/lisp/school/school-db.lisp
@@ -228,6 +228,12 @@ Returns plist stats: :scanned :updated :rewritten :defaulted :remaining."
   (handler-case
       (execute-non-query "ALTER TABLE strategies ADD COLUMN updated_at INTEGER")
     (error () nil))
+  ;; P5 (Thread B): integrity checksum for the data_sexp blob. Populated by
+  ;; upsert-strategy at write time; re-verified by the persistence audit so
+  ;; bit-rot/truncation is caught instead of being silently skipped by safe-read.
+  (handler-case
+      (execute-non-query "ALTER TABLE strategies ADD COLUMN data_sexp_sha256 TEXT")
+    (error () nil))
 
   ;; Table: Trades
   (execute-non-query
@@ -560,42 +566,56 @@ Returns plist stats: :scanned :updated :rewritten :defaulted :remaining."
               cur-cpcv-wr db-cpcv-wr
               cur-cpcv-maxdd db-cpcv-maxdd
               cur-cpcv-pass db-cpcv-pass)))
-    (handler-case
-        (execute-non-query
-         "INSERT OR REPLACE INTO strategies (
+    ;; P5 (Thread B): serialize once, cap the size, and checksum the blob.
+    ;; An oversize serialization is treated as corruption/pathology: we persist
+    ;; a short sentinel instead of the blob (all real metric columns still land)
+    ;; so a poison blob can neither bloat the DB nor choke safe-read downstream.
+    (let* ((raw-sexp (format nil "~s" strat))
+           (oversize (> (length raw-sexp) swimmy.core:*max-data-sexp-length*))
+           (data-sexp (if oversize
+                          (format nil ":OVERSIZE:~a" (length raw-sexp))
+                          raw-sexp))
+           (data-sexp-sha (swimmy.core:sha256-hex data-sexp)))
+      (when oversize
+        (format t "[DB] ⚠️ data_sexp for ~a is ~a chars (> ~a cap); storing sentinel.~%"
+                name (length raw-sexp) swimmy.core:*max-data-sexp-length*))
+      (handler-case
+          (execute-non-query
+           "INSERT OR REPLACE INTO strategies (
           name, indicators, entry, exit, sl, tp, volume,
           sharpe, profit_factor, win_rate, trades, max_dd,
           category, timeframe, generation, rank, symbol, direction, hash,
-          oos_sharpe, cpcv_median, cpcv_median_pf, cpcv_median_wr, cpcv_median_maxdd, cpcv_pass_rate, data_sexp, updated_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
-         name
-         (format nil "~a" (strategy-indicators strat))
-         (format nil "~a" (strategy-entry strat))
-         (format nil "~a" (strategy-exit strat))
-         (strategy-sl strat)
-         (strategy-tp strat)
-         (strategy-volume strat)
-         cur-sharpe
-         cur-pf
-         cur-wr
-         cur-trades
-         cur-max-dd
-         (format nil "~a" (strategy-category strat))
-         (strategy-timeframe strat)
-         (strategy-generation strat)
-         (format nil "~s" incoming-rank) ; Store as ":RANK"
-         (or (strategy-symbol strat) "USDJPY")
-         (format nil "~a" (strategy-direction strat))
-         (strategy-hash strat)
-         cur-oos ; P1: nil -> SQL NULL (unvalidated); preserves a real persisted OOS
-         cur-cpcv-median
-         cur-cpcv-pf
-         cur-cpcv-wr
-         cur-cpcv-maxdd
-         cur-cpcv-pass
-         (format nil "~s" strat)
-         updated-at) ; Store full serialized object as backup
-      (error (e) (format t "[DB] ❌ Upsert error for ~a: ~a~%" (strategy-name strat) e))))
+          oos_sharpe, cpcv_median, cpcv_median_pf, cpcv_median_wr, cpcv_median_maxdd, cpcv_pass_rate, data_sexp, data_sexp_sha256, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+           name
+           (format nil "~a" (strategy-indicators strat))
+           (format nil "~a" (strategy-entry strat))
+           (format nil "~a" (strategy-exit strat))
+           (strategy-sl strat)
+           (strategy-tp strat)
+           (strategy-volume strat)
+           cur-sharpe
+           cur-pf
+           cur-wr
+           cur-trades
+           cur-max-dd
+           (format nil "~a" (strategy-category strat))
+           (strategy-timeframe strat)
+           (strategy-generation strat)
+           (format nil "~s" incoming-rank) ; Store as ":RANK"
+           (or (strategy-symbol strat) "USDJPY")
+           (format nil "~a" (strategy-direction strat))
+           (strategy-hash strat)
+           cur-oos ; P1: nil -> SQL NULL (unvalidated); preserves a real persisted OOS
+           cur-cpcv-median
+           cur-cpcv-pf
+           cur-cpcv-wr
+           cur-cpcv-maxdd
+           cur-cpcv-pass
+           data-sexp          ; Store full serialized object as backup (or sentinel)
+           data-sexp-sha      ; P5: sha256 integrity checksum of data_sexp
+           updated-at)
+        (error (e) (format t "[DB] ❌ Upsert error for ~a: ~a~%" (strategy-name strat) e)))))
   )
 
 (defun update-cpcv-metrics-by-name (name median median-pf median-wr median-maxdd pass-rate

--- a/systemd/swimmy-alert@.service
+++ b/systemd/swimmy-alert@.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Swimmy failure alert for %i
+# P4 (Thread B / reliability): OnFailure sink for the brain-family units.
+# The failing unit references this as OnFailure=swimmy-alert@%n.service, so %i
+# expands to the full unit name (e.g. swimmy-brain.service). Deliberately has
+# NO OnFailure= / Restart= of its own so the alerter can never fail-loop.
+
+[Service]
+Type=oneshot
+User=swimmy
+Group=swimmy
+WorkingDirectory=/home/swimmy/swimmy
+Environment=HOME=/home/swimmy
+Environment=SWIMMY_HOME=/home/swimmy/swimmy
+# Alerting only needs the webhook; keep the environment minimal and optional so
+# a missing file never blocks the alert.
+EnvironmentFile=-/home/swimmy/swimmy/.env
+EnvironmentFile=-/home/swimmy/swimmy/config/.env.systemd
+ExecStart=/home/swimmy/swimmy/tools/ops/alert_on_failure.sh %i
+StandardOutput=append:/home/swimmy/swimmy/logs/alert.log
+StandardError=append:/home/swimmy/swimmy/logs/alert.log
+SyslogIdentifier=swimmy-alert

--- a/systemd/swimmy-brain.service
+++ b/systemd/swimmy-brain.service
@@ -22,8 +22,12 @@ RestartSec=30
 
 # Environment
 Environment=HOME=/home/swimmy
-Environment=SWIMMY_SBCL_DYNAMIC_SPACE_MB=4096
+# P4: heap comes from the split-name var (brain default 3072). run.sh reads
+# SWIMMY_BRAIN_HEAP_MB. /etc/swimmy/heap.env is loaded LAST so it is the single
+# source of truth, overriding this default and anything in .env.
+Environment=SWIMMY_BRAIN_HEAP_MB=3072
 EnvironmentFile=/home/swimmy/swimmy/.env
+EnvironmentFile=-/etc/swimmy/heap.env
 
 # Logging
 StandardOutput=journal

--- a/systemd/swimmy-brain.service
+++ b/systemd/swimmy-brain.service
@@ -2,6 +2,14 @@
 Description=Swimmy Brain Service
 Documentation=https://github.com/swimmy/swimmy
 After=network.target
+# P4 (Thread B): bound the restart budget so a poison-data / unrecoverable
+# boot fault stops PERMANENTLY instead of looping forever (was Restart=always
+# with no StartLimit). After 5 failures in 600s the unit enters `failed` and
+# OnFailure fires the alert; Guardian's brain-disconnect gate then keeps new
+# entries blocked (degraded operation) while existing positions are held.
+StartLimitIntervalSec=600
+StartLimitBurst=5
+OnFailure=swimmy-alert@%n.service
 
 [Service]
 Type=simple
@@ -9,8 +17,8 @@ User=swimmy
 Group=swimmy
 WorkingDirectory=/home/swimmy/swimmy
 ExecStart=/home/swimmy/swimmy/run.sh
-Restart=always
-RestartSec=10
+Restart=on-failure
+RestartSec=30
 
 # Environment
 Environment=HOME=/home/swimmy

--- a/systemd/swimmy-data-keeper.service
+++ b/systemd/swimmy-data-keeper.service
@@ -12,6 +12,11 @@ WorkingDirectory=/home/swimmy/swimmy
 ExecStart=/home/swimmy/swimmy/.venv/bin/python3 /home/swimmy/swimmy/tools/data_keeper.py
 Restart=always
 RestartSec=10
+# P4 (Thread B): cap the data-keeper's resident memory via the cgroup so a
+# runaway read/merge cannot starve the brain (3072MB) and school (4096MB)
+# heaps on the shared ops box. On OOM the cgroup kills only this unit, which
+# Restart=always then relaunches cleanly.
+MemoryMax=3G
 Environment=HOME=/home/swimmy
 Environment=PYTHONUNBUFFERED=1
 EnvironmentFile=/home/swimmy/swimmy/.env

--- a/systemd/swimmy-persistence-audit.service
+++ b/systemd/swimmy-persistence-audit.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Swimmy Persistence Audit (P5: read-only corruption / drift checks)
+After=network.target
+# A monotonic-invariant violation exits non-zero -> `failed` -> alert.
+OnFailure=swimmy-alert@%n.service
+
+[Service]
+Type=oneshot
+User=swimmy
+Group=swimmy
+WorkingDirectory=/home/swimmy/swimmy
+ExecStart=/home/swimmy/swimmy/.venv/bin/python3 /home/swimmy/swimmy/tools/persistence_audit.py
+Environment=HOME=/home/swimmy
+EnvironmentFile=-/home/swimmy/swimmy/.env
+StandardOutput=append:/home/swimmy/swimmy/logs/persistence_audit.log
+StandardError=append:/home/swimmy/swimmy/logs/persistence_audit.log
+
+[Install]
+WantedBy=default.target

--- a/systemd/swimmy-persistence-audit.timer
+++ b/systemd/swimmy-persistence-audit.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run Swimmy Persistence Audit daily (P5)
+
+[Timer]
+OnCalendar=*-*-* 05:20:00
+Persistent=true
+RandomizedDelaySec=15min
+
+[Install]
+WantedBy=timers.target

--- a/systemd/swimmy-school.service
+++ b/systemd/swimmy-school.service
@@ -16,14 +16,18 @@ User=swimmy
 Group=swimmy
 WorkingDirectory=/home/swimmy/swimmy
 ExecStartPre=/usr/bin/sbcl --disable-debugger --script /home/swimmy/swimmy/tools/restore_legend_61.lisp
-ExecStart=/usr/bin/sbcl --dynamic-space-size ${SWIMMY_SBCL_DYNAMIC_SPACE_MB} --noinform --load /home/swimmy/swimmy/src/lisp/school/school-daemon.lisp
+ExecStart=/usr/bin/sbcl --dynamic-space-size ${SWIMMY_SCHOOL_HEAP_MB} --noinform --load /home/swimmy/swimmy/src/lisp/school/school-daemon.lisp
 Restart=on-failure
 RestartSec=30
 
 # Environment
 Environment=HOME=/home/swimmy
-Environment=SWIMMY_SBCL_DYNAMIC_SPACE_MB=4096
+# P4: heap comes from the split-name var (school default 4096). ExecStart
+# substitutes SWIMMY_SCHOOL_HEAP_MB. /etc/swimmy/heap.env is loaded LAST so it
+# is the single source of truth, overriding this default and anything in .env.
+Environment=SWIMMY_SCHOOL_HEAP_MB=4096
 EnvironmentFile=/home/swimmy/swimmy/.env
+EnvironmentFile=-/etc/swimmy/heap.env
 
 # Logging
 StandardOutput=journal

--- a/systemd/swimmy-school.service
+++ b/systemd/swimmy-school.service
@@ -2,6 +2,13 @@
 Description=Swimmy School Service
 Documentation=https://github.com/swimmy/swimmy
 After=network.target
+# P4 (Thread B): the school daemon uses "Let It Crash" (school-daemon.lisp:10-17
+# exits 1 on any unhandled error). Paired with the old Restart=always/no-limit
+# this immortalized poison data via an infinite restart loop. Bound the budget
+# so 5 failures in 600s parks the unit in `failed` and fires OnFailure.
+StartLimitIntervalSec=600
+StartLimitBurst=5
+OnFailure=swimmy-alert@%n.service
 
 [Service]
 Type=simple
@@ -10,8 +17,8 @@ Group=swimmy
 WorkingDirectory=/home/swimmy/swimmy
 ExecStartPre=/usr/bin/sbcl --disable-debugger --script /home/swimmy/swimmy/tools/restore_legend_61.lisp
 ExecStart=/usr/bin/sbcl --dynamic-space-size ${SWIMMY_SBCL_DYNAMIC_SPACE_MB} --noinform --load /home/swimmy/swimmy/src/lisp/school/school-daemon.lisp
-Restart=always
-RestartSec=10
+Restart=on-failure
+RestartSec=30
 
 # Environment
 Environment=HOME=/home/swimmy

--- a/tests/p5_audit_test.py
+++ b/tests/p5_audit_test.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""P5 — end-to-end test for tools/persistence_audit.py against a synthetic DB."""
+import hashlib
+import json
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+AUDIT = os.path.join(ROOT, "tools", "persistence_audit.py")
+failures = []
+
+
+def check(desc, cond):
+    print(("  ok: " if cond else "FAIL: ") + desc)
+    if not cond:
+        failures.append(desc)
+
+
+def sha(s):
+    return hashlib.sha256(s.encode("utf-8")).hexdigest()
+
+
+def build_db(path):
+    con = sqlite3.connect(path)
+    c = con.cursor()
+    c.execute("""CREATE TABLE strategies (
+        name TEXT PRIMARY KEY, rank TEXT, hash TEXT, sharpe REAL,
+        data_sexp TEXT, data_sexp_sha256 TEXT, updated_at INTEGER)""")
+    good = '#S(STRATEGY :NAME "Good")'
+    rows = [
+        ("Good1", ":B", "abc", 1.0, good, sha(good)),
+        ("Good2", ":A", "def", 1.2, good, sha(good)),
+        ("Gy1", ":GRAVEYARD", "h1", -1.0, good, sha(good)),
+        ("Gy2", ":GRAVEYARD", "h2", -2.0, good, sha(good)),
+        # corrupted blob: stored checksum no longer matches (bit-rot)
+        ("Rot", ":B", "h3", 0.3, good + "XX", sha(good)),
+        # quarantined
+        ("Corr", ":CORRUPT", ":INVALID", 0.0, "@@garbage@@", sha("@@garbage@@")),
+        # oversize sentinel
+        ("Big", ":B", "h4", 0.4, ":OVERSIZE:999999", sha(":OVERSIZE:999999")),
+        # hash invalid marker
+        ("Inv", ":CORRUPT", ":INVALID", 0.0, "junk", sha("junk")),
+    ]
+    c.executemany(
+        "INSERT INTO strategies (name,rank,hash,sharpe,data_sexp,data_sexp_sha256)"
+        " VALUES (?,?,?,?,?,?)", rows)
+    con.commit(); con.close()
+
+
+def run_audit(db, hwm, lib):
+    p = subprocess.run(
+        [sys.executable, AUDIT, "--db", db, "--hwm", hwm, "--library", lib, "--json"],
+        capture_output=True, text=True)
+    return p.returncode, json.loads(p.stdout.strip().splitlines()[-1])
+
+
+def main():
+    d = tempfile.mkdtemp()
+    try:
+        db = os.path.join(d, "swimmy.db")
+        hwm = os.path.join(d, ".graveyard_hwm")
+        lib = os.path.join(d, "library")
+        os.makedirs(os.path.join(lib, "B"))
+        for nm in ("Good1", "Good2", "extra"):
+            open(os.path.join(lib, "B", nm + ".lisp"), "w").close()
+        build_db(db)
+
+        rc, r = run_audit(db, hwm, lib)
+        # run1 exits 1 because the DB seeds a checksum-mismatch row (Rot);
+        # that is itself a violation. The hwm is still recorded regardless.
+        check("run1 exit 1 (seeded checksum mismatch is a violation)", rc == 1)
+        check("graveyard counted (2)", r["graveyard_count"] == 2)
+        check("hwm initialized to 2", r["graveyard_hwm"] in (0, 2) and os.path.exists(hwm))
+        check("checksum mismatch detected (Rot)", r["checksum_mismatch"] == 1)
+        check("hash_invalid counted (2)", r["hash_invalid"] == 2)
+        check("quarantined :CORRUPT counted (2)", r["quarantined_corrupt"] == 2)
+        check("oversize sentinel counted (1)", r["oversize_sentinels"] == 1)
+        check("library files counted (3)", r["library_files"] == 3)
+        # active ranks = B/A/S/LEGEND*: Good1,Good2,Rot,Big = 4
+        check("active sql rows (4)", r["active_sql_rows"] == 4)
+        check("drift = 3 - 4 = -1", r["library_vs_sql_drift"] == -1)
+        check("run1 reports checksum violation", any("checksum" in v for v in r["violations"]))
+
+        # stamp should now hold hwm=2
+        check("hwm persisted as 2", open(hwm).read().strip() == "2")
+
+        # Now DELETE a graveyard row -> count drops below hwm -> HARD violation
+        con = sqlite3.connect(db); con.execute("DELETE FROM strategies WHERE name='Gy1'")
+        con.commit(); con.close()
+        rc2, r2 = run_audit(db, hwm, lib)
+        check("run2 graveyard shrank to 1", r2["graveyard_count"] == 1)
+        check("run2 exit 1 (monotonic invariant violated)", rc2 == 1)
+        check("run2 reports graveyard-shrank violation",
+              any("graveyard shrank" in v for v in r2["violations"]))
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+    if failures:
+        print("\np5_audit_test: FAILED (%d)" % len(failures), file=sys.stderr)
+        return 1
+    print("\np5_audit_test: persistence audit behaves correctly")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/p5_persistence_sql_test.py
+++ b/tests/p5_persistence_sql_test.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""P5 (Thread B / persistence hardening) — SQL-semantics tests.
+
+Exercises the exact SQLite behaviors the Lisp persistence layer relies on,
+against the same SQLite engine, so they are verifiable offline on any host
+(the Lisp side needs the vendored sqlite DLL / full system to load). Covers:
+  * data_sexp_sha256 column migration + idempotency
+  * BEGIN IMMEDIATE / COMMIT / ROLLBACK atomicity (record-graveyard-pattern)
+  * sha256 checksum roundtrip (sha256-hex)
+  * :CORRUPT quarantine is excluded from the active/breeding allow-list
+  * oversize sentinel is written instead of the blob
+  * graveyard monotonic-non-decreasing invariant (audit)
+"""
+import hashlib
+import sqlite3
+import sys
+import tempfile
+import os
+
+MAX_DATA_SEXP_LENGTH = 262144  # mirrors swimmy.core:*max-data-sexp-length*
+
+failures = []
+
+
+def check(desc, cond):
+    print(("  ok: " if cond else "FAIL: ") + desc)
+    if not cond:
+        failures.append(desc)
+
+
+def sha256_hex(s: str) -> str:
+    return hashlib.sha256(s.encode("utf-8")).hexdigest()
+
+
+def base_schema(cur):
+    # Minimal shape mirroring strategies (only columns these tests touch).
+    cur.execute("""CREATE TABLE strategies (
+        name TEXT PRIMARY KEY, rank TEXT, hash TEXT,
+        sharpe REAL, data_sexp TEXT, updated_at INTEGER)""")
+
+
+def test_migration_idempotent():
+    con = sqlite3.connect(":memory:")
+    cur = con.cursor()
+    base_schema(cur)
+    cur.execute("ALTER TABLE strategies ADD COLUMN data_sexp_sha256 TEXT")
+    cols = [r[1] for r in cur.execute("PRAGMA table_info(strategies)")]
+    check("migration adds data_sexp_sha256", "data_sexp_sha256" in cols)
+    # second ADD raises (handler-case swallows it in Lisp) -> idempotent
+    raised = False
+    try:
+        cur.execute("ALTER TABLE strategies ADD COLUMN data_sexp_sha256 TEXT")
+    except sqlite3.OperationalError:
+        raised = True
+    check("re-adding column raises (idempotent via caught error)", raised)
+    con.close()
+
+
+def test_immediate_tx_atomicity():
+    path = os.path.join(tempfile.mkdtemp(), "p5.db")
+    con = sqlite3.connect(path, isolation_level=None)  # manual tx control
+    cur = con.cursor()
+    base_schema(cur)
+    cur.execute("ALTER TABLE strategies ADD COLUMN data_sexp_sha256 TEXT")
+
+    # commit path (record-graveyard-pattern happy path)
+    cur.execute("BEGIN IMMEDIATE")
+    s = '#S(STRATEGY :NAME "Foo")'
+    cur.execute("INSERT OR REPLACE INTO strategies (name,rank,data_sexp,data_sexp_sha256) VALUES (?,?,?,?)",
+                ("Foo", ":GRAVEYARD", s, sha256_hex(s)))
+    cur.execute("COMMIT")
+    n = cur.execute("SELECT count(*) FROM strategies").fetchone()[0]
+    check("after COMMIT graveyard row persists", n == 1)
+
+    # rollback path (error inside the immediate tx -> unwind-protect ROLLBACK)
+    try:
+        cur.execute("BEGIN IMMEDIATE")
+        cur.execute("INSERT OR REPLACE INTO strategies (name,rank,data_sexp) VALUES (?,?,?)",
+                    ("Bar", ":B", "x"))
+        raise RuntimeError("boom")
+    except RuntimeError:
+        cur.execute("ROLLBACK")
+    present = cur.execute("SELECT count(*) FROM strategies WHERE name='Bar'").fetchone()[0]
+    check("after ROLLBACK the failed write left no row", present == 0)
+    con.close()
+
+
+def test_checksum_roundtrip():
+    con = sqlite3.connect(":memory:"); cur = con.cursor()
+    base_schema(cur); cur.execute("ALTER TABLE strategies ADD COLUMN data_sexp_sha256 TEXT")
+    s = '#S(STRATEGY :NAME "Foo" :SHARPE 1.5)'
+    cur.execute("INSERT INTO strategies (name,data_sexp,data_sexp_sha256) VALUES (?,?,?)",
+                ("Foo", s, sha256_hex(s)))
+    stored, sm = cur.execute("SELECT data_sexp, data_sexp_sha256 FROM strategies WHERE name='Foo'").fetchone()
+    check("checksum matches intact blob", sha256_hex(stored) == sm)
+    # simulate bit-rot: mutate the blob without updating the checksum
+    cur.execute("UPDATE strategies SET data_sexp=? WHERE name='Foo'", (s + " CORRUPTED",))
+    stored2, sm2 = cur.execute("SELECT data_sexp, data_sexp_sha256 FROM strategies WHERE name='Foo'").fetchone()
+    check("checksum MISMATCH detects corruption", sha256_hex(stored2) != sm2)
+    con.close()
+
+
+def test_oversize_sentinel():
+    raw = "x" * (MAX_DATA_SEXP_LENGTH + 10)
+    oversize = len(raw) > MAX_DATA_SEXP_LENGTH
+    data_sexp = (":OVERSIZE:%d" % len(raw)) if oversize else raw
+    check("oversize blob replaced by sentinel", data_sexp.startswith(":OVERSIZE:") and len(data_sexp) < 40)
+    small = "y" * 100
+    keep = small if len(small) <= MAX_DATA_SEXP_LENGTH else ("...")
+    check("normal blob stored verbatim", keep == small)
+
+
+def test_corrupt_quarantine_excluded():
+    con = sqlite3.connect(":memory:"); cur = con.cursor()
+    base_schema(cur)
+    rows = [("Good", ":B", 1.2), ("Bad", ":B", 0.5)]
+    cur.executemany("INSERT INTO strategies (name,rank,sharpe) VALUES (?,?,?)", rows)
+    # quarantine Bad (as cemetery-audit-db does): never DELETE
+    cur.execute("UPDATE strategies SET hash=':INVALID', rank=':CORRUPT' WHERE name='Bad'")
+    survived = cur.execute("SELECT count(*) FROM strategies WHERE name='Bad'").fetchone()[0]
+    check("quarantined row is NOT deleted", survived == 1)
+    # the active/breeding allow-list (fetch-candidate-strategies ranks B/A/S)
+    active = [r[0] for r in cur.execute(
+        "SELECT name FROM strategies WHERE rank IN (':B',':A',':S')")]
+    check(":CORRUPT excluded from active allow-list", active == ["Good"])
+    con.close()
+
+
+def test_graveyard_monotonic_invariant():
+    # audit's high-water-mark check: current graveyard count must never drop.
+    def violated(prev_hwm, current):
+        return current < prev_hwm
+    check("hwm: growth is fine", not violated(10, 12))
+    check("hwm: equal is fine", not violated(12, 12))
+    check("hwm: shrink is a VIOLATION", violated(12, 9))
+
+
+if __name__ == "__main__":
+    test_migration_idempotent()
+    test_immediate_tx_atomicity()
+    test_checksum_roundtrip()
+    test_oversize_sentinel()
+    test_corrupt_quarantine_excluded()
+    test_graveyard_monotonic_invariant()
+    if failures:
+        print("\np5_persistence_sql_test: FAILED (%d)" % len(failures), file=sys.stderr)
+        sys.exit(1)
+    print("\np5_persistence_sql_test: all SQL-semantics invariants hold")

--- a/tests/systemd_reliability_test.sh
+++ b/tests/systemd_reliability_test.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# tests/systemd_reliability_test.sh
+# ============================================================================
+# P4 (Thread B / reliability) invariants. Pure static assertions over the repo
+# unit/config/script files — no systemd required, runs on any host.
+# ============================================================================
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root"
+
+fail=0
+check() {  # check "<description>" <test-expression...>
+    local desc="$1"; shift
+    if "$@"; then
+        echo "  ok: $desc"
+    else
+        echo "FAIL: $desc" >&2
+        fail=1
+    fi
+}
+has()   { grep -qF -- "$2" "$1"; }          # fixed-string present
+hasE()  { grep -qE -- "$2" "$1"; }          # regex present
+lacks() { ! grep -qF -- "$2" "$1"; }        # fixed-string absent
+# absent as an ACTIVE directive (anchored at col 0; ignores '# ...' comments)
+lacksD(){ ! grep -qE -- "^$2" "$1"; }
+
+brain="systemd/swimmy-brain.service"
+school="systemd/swimmy-school.service"
+dk="systemd/swimmy-data-keeper.service"
+alert="systemd/swimmy-alert@.service"
+
+# --- 1. crash-loop discipline on brain + school ---------------------------
+for u in "$brain" "$school"; do
+    check "$u Restart=on-failure"          has "$u" "Restart=on-failure"
+    check "$u no active Restart=always"    lacksD "$u" "Restart=always"
+    check "$u RestartSec=30"               has "$u" "RestartSec=30"
+    check "$u StartLimitIntervalSec=600"   has "$u" "StartLimitIntervalSec=600"
+    check "$u StartLimitBurst=5"           has "$u" "StartLimitBurst=5"
+    check "$u OnFailure alert wired"       has "$u" "OnFailure=swimmy-alert@%n.service"
+done
+
+# --- 2. heap centralization + split var names -----------------------------
+check "config/heap.env brain=3072"   has "config/heap.env" "SWIMMY_BRAIN_HEAP_MB=3072"
+check "config/heap.env school=4096"  has "config/heap.env" "SWIMMY_SCHOOL_HEAP_MB=4096"
+check "brain loads heap.env"         has "$brain"  "EnvironmentFile=-/etc/swimmy/heap.env"
+check "school loads heap.env"        has "$school" "EnvironmentFile=-/etc/swimmy/heap.env"
+check "brain default BRAIN_HEAP_MB"  has "$brain"  "Environment=SWIMMY_BRAIN_HEAP_MB=3072"
+check "school default SCHOOL_HEAP_MB" has "$school" "Environment=SWIMMY_SCHOOL_HEAP_MB=4096"
+check "school ExecStart uses SCHOOL_HEAP_MB" has "$school" 'dynamic-space-size ${SWIMMY_SCHOOL_HEAP_MB}'
+# split names: neither brain nor school still pins the legacy shared var
+check "brain drops legacy heap var"  lacks "$brain"  "Environment=SWIMMY_SBCL_DYNAMIC_SPACE_MB"
+check "school drops legacy heap var" lacks "$school" "Environment=SWIMMY_SBCL_DYNAMIC_SPACE_MB"
+check "run.sh prefers BRAIN_HEAP_MB" has "run.sh" 'SWIMMY_BRAIN_HEAP_MB:-'
+
+# --- 3. data-keeper memory cap --------------------------------------------
+check "data-keeper MemoryMax=3G"     has "$dk" "MemoryMax=3G"
+
+# --- 4. alerter cannot fail-loop ------------------------------------------
+check "alert unit is oneshot"        has "$alert" "Type=oneshot"
+check "alert unit no active Restart="   lacksD "$alert" "Restart="
+check "alert unit no active OnFailure=" lacksD "$alert" "OnFailure="
+check "alert script exits 0"         has "tools/ops/alert_on_failure.sh" "exit 0"
+check "alert script executable"      test -x "tools/ops/alert_on_failure.sh"
+
+# --- 5. EOL protection for ops files --------------------------------------
+check ".gitattributes pins *.sh lf"      hasE ".gitattributes" '^\*\.sh[[:space:]]+text eol=lf'
+check ".gitattributes pins *.service lf" hasE ".gitattributes" '^\*\.service text eol=lf'
+
+if [ "$fail" -ne 0 ]; then
+    echo "systemd_reliability_test: FAILED" >&2
+    exit 1
+fi
+echo "systemd_reliability_test: all P4 invariants hold"

--- a/tools/ops/alert_on_failure.sh
+++ b/tools/ops/alert_on_failure.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# tools/ops/alert_on_failure.sh
+# ============================================================================
+# P4 (Thread B / reliability): OnFailure alert sink for the brain-family units.
+# ----------------------------------------------------------------------------
+# Invoked by swimmy-alert@.service, which is wired as `OnFailure=` on the
+# school/brain units. systemd fires it once the failing unit has exhausted its
+# StartLimitBurst and entered the `failed` state (i.e. a PERMANENT stop, not a
+# transient blip) -- exactly the condition P4 wants surfaced loudly.
+#
+# Contract:
+#   $1 = the failed unit name (passed by the template as %i, e.g.
+#        "swimmy-brain.service").
+#
+# This script MUST NOT itself fail-loop: it always exits 0. The Discord ping is
+# strictly opt-in (only fires when SWIMMY_DISCORD_ALERTS is already configured
+# by the owner) and best-effort; the durable log line is the guaranteed record.
+# Mirrors the established webhook idiom in tools/check_school_health.sh.
+# ============================================================================
+
+set -uo pipefail
+
+UNIT="${1:-unknown.unit}"
+SWIMMY_HOME="${SWIMMY_HOME:-/home/swimmy/swimmy}"
+LOG_DIR="${SWIMMY_HOME}/logs"
+LOG_FILE="${LOG_DIR}/alert.log"
+WEBHOOK_URL="${SWIMMY_DISCORD_ALERTS:-}"
+
+mkdir -p "${LOG_DIR}" 2>/dev/null || true
+
+ts="$(date '+%Y-%m-%d %H:%M:%S %Z')"
+
+# Grab a little context from the failed unit's recent journal (best-effort;
+# absent on non-systemd hosts).
+context=""
+if command -v journalctl >/dev/null 2>&1; then
+    context="$(journalctl -u "${UNIT}" -n 8 --no-pager 2>/dev/null | tail -n 8)"
+fi
+
+{
+    echo "==================================================================="
+    echo "[${ts}] 🛑 UNIT FAILED (permanent stop after StartLimit): ${UNIT}"
+    if [ -n "${context}" ]; then
+        echo "--- last journal lines --------------------------------------------"
+        echo "${context}"
+        echo "-------------------------------------------------------------------"
+    fi
+} >> "${LOG_FILE}" 2>/dev/null || true
+
+# Opt-in Discord ping: only when the owner has already set the webhook.
+if [ -n "${WEBHOOK_URL}" ]; then
+    desc="Unit \`${UNIT}\` exhausted its restart budget and is now in the failed state (permanent stop). New entries are already blocked by Guardian's brain-disconnect gate; existing positions are held under protective management. Manual intervention required."
+    payload="$(cat <<JSON
+{"content":"@here","embeds":[{"title":"🛑 SWIMMY UNIT DOWN (permanent)","description":"${desc}","color":16711680,"footer":{"text":"swimmy-alert@ / OnFailure"}}]}
+JSON
+)"
+    curl -s -m 10 -H "Content-Type: application/json" \
+        -d "${payload}" "${WEBHOOK_URL}" >/dev/null 2>&1 || true
+fi
+
+exit 0

--- a/tools/ops/install_heap_env.sh
+++ b/tools/ops/install_heap_env.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# tools/ops/install_heap_env.sh
+# ============================================================================
+# P4 (Thread B / reliability): install the canonical SBCL heap config to
+# /etc/swimmy/heap.env, the single source of truth loaded (last) by both
+# swimmy-brain.service and swimmy-school.service.
+#
+# Idempotent: re-running only rewrites the target if it differs from the repo
+# template. Run as root (sudo). Does NOT restart services — the caller decides
+# when to `systemctl daemon-reload` and restart brain/school.
+# ============================================================================
+
+set -euo pipefail
+
+SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SRC="${SRC_DIR}/config/heap.env"
+DEST_DIR="/etc/swimmy"
+DEST="${DEST_DIR}/heap.env"
+
+if [ ! -f "${SRC}" ]; then
+    echo "❌ Template not found: ${SRC}" >&2
+    exit 1
+fi
+
+if [ "${EUID:-$(id -u)}" -ne 0 ]; then
+    echo "❌ Must run as root (sudo) to write ${DEST}" >&2
+    exit 1
+fi
+
+install -d -m 0755 "${DEST_DIR}"
+
+if [ -f "${DEST}" ] && cmp -s "${SRC}" "${DEST}"; then
+    echo "✅ ${DEST} already up to date."
+    exit 0
+fi
+
+install -m 0644 "${SRC}" "${DEST}"
+echo "✅ Installed ${DEST}:"
+sed -n 's/^\(SWIMMY_[A-Z_]*=.*\)/    \1/p' "${DEST}"
+echo ""
+echo "Next: sudo systemctl daemon-reload && sudo systemctl restart swimmy-brain swimmy-school"

--- a/tools/persistence_audit.py
+++ b/tools/persistence_audit.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""P5 (Thread B / persistence hardening) — read-only persistence audit.
+
+A daily, READ-ONLY health check over the strategies store. It opens the DB in
+SQLite read-only mode and never mutates strategy data; its only write is a tiny
+high-water-mark stamp file used for the graveyard monotonicity invariant.
+
+Checks:
+  1. graveyard monotonic non-decreasing  — the graveyard is append-only; if the
+     :GRAVEYARD count ever drops below the recorded high-water mark, rows were
+     lost/deleted (a HARD invariant -> non-zero exit).
+  2. data_sexp checksum integrity        — recompute sha256(data_sexp) and
+     compare to the stored data_sexp_sha256; mismatches = silent bit-rot.
+  3. hash ':INVALID' ratio               — rows the cemetery audit could not parse.
+  4. :CORRUPT quarantine count           — rows quarantined by P5-D.
+  5. oversize sentinel count             — data_sexp replaced by ':OVERSIZE:'.
+  6. library files vs SQL rows           — reconcile data/library/<rank>/*.lisp
+     file count against the SQL row count; report drift.
+
+Exit code: 0 when the hard invariant holds, 1 when the graveyard shrank.
+On violation, an opt-in Discord ping fires only if SWIMMY_DISCORD_ALERTS is set.
+"""
+import argparse
+import glob
+import hashlib
+import json
+import os
+import sqlite3
+import sys
+import time
+
+ACTIVE_RANKS = (":B", ":A", ":S", ":LEGEND", ":LEGEND-ARCHIVE")
+
+
+def sha256_hex(s):
+    return hashlib.sha256(s.encode("utf-8")).hexdigest()
+
+
+def connect_ro(db_path):
+    uri = "file:%s?mode=ro" % os.path.abspath(db_path).replace("?", "%3f")
+    return sqlite3.connect(uri, uri=True)
+
+
+def has_column(cur, table, col):
+    return col in {r[1] for r in cur.execute("PRAGMA table_info(%s)" % table)}
+
+
+def audit(db_path, hwm_path, library_path):
+    report = {"ts": int(time.time()), "db": db_path, "violations": []}
+    con = connect_ro(db_path)
+    cur = con.cursor()
+
+    total = cur.execute("SELECT COUNT(*) FROM strategies").fetchone()[0]
+    report["total_rows"] = total
+
+    # 1. graveyard monotonic non-decreasing
+    gy = cur.execute(
+        "SELECT COUNT(*) FROM strategies WHERE UPPER(TRIM(rank))=':GRAVEYARD'"
+    ).fetchone()[0]
+    prev_hwm = 0
+    if os.path.exists(hwm_path):
+        try:
+            prev_hwm = int(open(hwm_path).read().strip() or "0")
+        except (ValueError, OSError):
+            prev_hwm = 0
+    report["graveyard_count"] = gy
+    report["graveyard_hwm"] = prev_hwm
+    if gy < prev_hwm:
+        report["violations"].append(
+            "graveyard shrank: %d < high-water-mark %d (rows lost?)" % (gy, prev_hwm))
+    new_hwm = max(gy, prev_hwm)
+    try:
+        os.makedirs(os.path.dirname(hwm_path) or ".", exist_ok=True)
+        tmp = "%s.%d.tmp" % (hwm_path, os.getpid())
+        with open(tmp, "w") as f:
+            f.write(str(new_hwm))
+        os.replace(tmp, hwm_path)  # atomic
+    except OSError as e:
+        report.setdefault("warnings", []).append("could not persist hwm: %s" % e)
+
+    # 2. checksum integrity (only if the P5 column exists)
+    mism = unchecked = 0
+    if has_column(cur, "strategies", "data_sexp_sha256"):
+        for blob, stored in cur.execute(
+            "SELECT data_sexp, data_sexp_sha256 FROM strategies "
+            "WHERE data_sexp IS NOT NULL AND TRIM(data_sexp) <> ''"
+        ):
+            if stored is None or stored == "":
+                unchecked += 1
+            elif sha256_hex(blob) != stored:
+                mism += 1
+    report["checksum_mismatch"] = mism
+    report["checksum_unchecked"] = unchecked
+    if mism > 0:
+        report["violations"].append("%d data_sexp checksum mismatch(es)" % mism)
+
+    # 3. hash ':INVALID' ratio
+    invalid = cur.execute(
+        "SELECT COUNT(*) FROM strategies WHERE hash=':INVALID'").fetchone()[0]
+    report["hash_invalid"] = invalid
+    report["hash_invalid_ratio"] = round(invalid / total, 4) if total else 0.0
+
+    # 4. :CORRUPT quarantine count
+    corrupt = cur.execute(
+        "SELECT COUNT(*) FROM strategies WHERE UPPER(TRIM(rank))=':CORRUPT'"
+    ).fetchone()[0]
+    report["quarantined_corrupt"] = corrupt
+
+    # 5. oversize sentinels
+    oversize = cur.execute(
+        "SELECT COUNT(*) FROM strategies WHERE data_sexp LIKE ':OVERSIZE:%'"
+    ).fetchone()[0]
+    report["oversize_sentinels"] = oversize
+
+    con.close()
+
+    # 6. library files vs SQL rows (active ranks)
+    lib_files = 0
+    if library_path and os.path.isdir(library_path):
+        lib_files = len(glob.glob(os.path.join(library_path, "*", "*.lisp")))
+    report["library_files"] = lib_files
+    con2 = connect_ro(db_path)
+    active_rows = con2.cursor().execute(
+        "SELECT COUNT(*) FROM strategies WHERE UPPER(TRIM(rank)) IN (%s)"
+        % ",".join("'%s'" % r for r in ACTIVE_RANKS)
+    ).fetchone()[0]
+    con2.close()
+    report["active_sql_rows"] = active_rows
+    report["library_vs_sql_drift"] = lib_files - active_rows
+
+    return report
+
+
+def maybe_alert(report):
+    webhook = os.getenv("SWIMMY_DISCORD_ALERTS", "")
+    if not webhook or not report["violations"]:
+        return
+    try:
+        import urllib.request
+        desc = "\\n".join("• " + v for v in report["violations"])
+        payload = json.dumps({
+            "content": "@here",
+            "embeds": [{
+                "title": "🧬 PERSISTENCE AUDIT VIOLATION",
+                "description": desc[:1800],
+                "color": 16711680,
+            }],
+        }).encode("utf-8")
+        req = urllib.request.Request(
+            webhook, data=payload, headers={"Content-Type": "application/json"})
+        urllib.request.urlopen(req, timeout=10).read()
+    except Exception:
+        pass  # best-effort
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--db", default="data/memory/swimmy.db")
+    ap.add_argument("--hwm", default="data/memory/.graveyard_hwm")
+    ap.add_argument("--library", default="data/library")
+    ap.add_argument("--log", default="logs/persistence_audit.log")
+    ap.add_argument("--json", action="store_true", help="print report as JSON")
+    args = ap.parse_args()
+
+    if not os.path.exists(args.db):
+        print("[AUDIT] DB not found: %s (skipping)" % args.db, file=sys.stderr)
+        return 0
+
+    report = audit(args.db, args.hwm, args.library)
+    line = json.dumps(report, sort_keys=True)
+
+    try:
+        os.makedirs(os.path.dirname(args.log) or ".", exist_ok=True)
+        with open(args.log, "a") as f:
+            f.write(line + "\n")
+    except OSError:
+        pass
+
+    print(line if args.json else
+          "[AUDIT] rows=%d graveyard=%d(hwm=%d) checksum_mismatch=%d "
+          "hash_invalid=%d corrupt=%d oversize=%d lib=%d/%d drift=%d %s" % (
+              report["total_rows"], report["graveyard_count"], report["graveyard_hwm"],
+              report["checksum_mismatch"], report["hash_invalid"],
+              report["quarantined_corrupt"], report["oversize_sentinels"],
+              report["library_files"], report["active_sql_rows"],
+              report["library_vs_sql_drift"],
+              "OK" if not report["violations"] else "VIOLATIONS: " + "; ".join(report["violations"])))
+
+    if report["violations"]:
+        maybe_alert(report)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 概要

Thread B（P4/P5）= 蠱毒 tribe 背骨部分再構築の **信頼性（P4）＋ 永続化破損耐性（P5）**。10 コミット。

- **設計正本**: `rebuild_design_fable_P1-P7_20260703.md` §3 P4/P5
- **P4 ops note**: [`doc/knowledge/p4_reliability_ops_20260712.md`](../blob/claude/thread-b-reliability-persistence/doc/knowledge/p4_reliability_ops_20260712.md)
- **P5 ops note**: [`doc/knowledge/p5_persistence_ops_20260712.md`](../blob/claude/thread-b-reliability-persistence/doc/knowledge/p5_persistence_ops_20260712.md)

> [!IMPORTANT]
> **systemd/env/永続化のみ。Rust Guardian のライブ発注・清算セマンティクスは一切不変。**
> **ライブ発注なし・swimmy.db 無改変・オフライン検証のみ・gate floor 不変。**
> **deploy はオーナーの WSL (Ubuntu, user=swimmy) 上で実施（手順は両 ops note §5）。**

## base について

base = `claude/thread-a-verification-wiring`（P1/P2/P3 を含む tribe-rebuild 統合線）。P4/P5 は P1/P2/P3 に依存し、それらは master に未反映のため master 直行は不可。本 PR 差分は **ちょうど P4/P5 の 10 コミット**。thread-a が master へ統合された後に base を master へ retarget 可能（stacked PR）。

## P4 — 信頼性（クラッシュループ／メモリ／ヒープ）

- **クラッシュループ根治**: `swimmy-brain`/`swimmy-school` を `Restart=always`(無制限) → `on-failure` / 30s / `StartLimitIntervalSec=600` + `StartLimitBurst=5` + `OnFailure=swimmy-alert@%n`。毒データの無限再起動不死化を恒久停止化。
- **OnFailure alert**: `systemd/swimmy-alert@.service`（oneshot）+ `tools/ops/alert_on_failure.sh`。durable `logs/alert.log` を必ず記録、alerter 自身は fail-loop しない。
- **ヒープ一元化**: `/etc/swimmy/heap.env`（`config/heap.env` 正本）。変数名を daemon 別に分離（`SWIMMY_BRAIN_HEAP_MB=3072` / `SWIMMY_SCHOOL_HEAP_MB=4096`）で一括置換事故を防止。
- **メモリ暴走隔離**: `swimmy-data-keeper` に cgroup `MemoryMax=3G`。
- **Guardian degraded 運転**は既存 brain-disconnect ゲートで成立（新規エントリ veto・既存ポジ管理継続）＝ Rust 追加変更不要。短TF emergency-close の是非のみ**オーナー判断事項**として ops note に明記（ライブ清算セマンティクス変更＝要オフライン外検証）。
- **回帰**: `tests/systemd_reliability_test.sh`、`.gitattributes` で `*.sh/*.service/*.timer/*.env` を `eol=lf` ピン。

## P5 — 永続化の破損耐性

- graveyard を `BEGIN IMMEDIATE…COMMIT`（RESERVED 先取り＝SQLITE_BUSY 敗北排除）。
- `data_sexp` に **sha256 checksum 列**＋256KB 上限（超過は `:OVERSIZE` sentinel、poison blob を DB に入れない）。
- tmp 名一意化 `<name>.<pid-token>-<counter>.tmp`（同一 FS で rename アトミック性確認済み）。
- **read-only 日次監査** `tools/persistence_audit.py` + `swimmy-persistence-audit.timer`（graveyard 単調非減少 invariant・checksum 整合・INVALID 比率、違反 exit1 → alert）。
- 破損行は**削除せず** `rank=:CORRUPT` / `hash=:INVALID` で quarantine（フォレンジック保全＋active 除外）。
- **検証**: SQL 意味論 `tests/p5_persistence_sql_test.py` 13/13 pass・監査 e2e `tests/p5_audit_test.py`・sha256 NIST `"abc"` ベクタ一致。⏳ WSL ホストで full `ql:quickload :swimmy` コンパイル通過のみ deploy 前に要実行（native-Windows は cl-sqlite DLL 未ロードで full-system ロード不可）。

## コミット（10）

```
30e7d061 docs(tribe-P5f): P5 persistence ops note + pin *.py to eol=lf
b4923d18 feat(tribe-P5e/f): read-only persistence audit + daily timer + SQL/audit tests
638df0fb feat(tribe-P5b): uniquify save-strategy atomic .tmp name (pid + counter)
f4cd6649 feat(tribe-P5a/d): atomic graveyard write + quarantine corrupt rows (:CORRUPT)
3d9b1b20 feat(tribe-P5a/c): immediate-tx + sha256 helpers; data_sexp checksum + size cap
2cac5795 test(tribe-P4g): static invariant test for the P4 reliability changes
4e332498 docs(tribe-P4e/f): P4 reliability ops note + correct 2 stale expert-panel claims
cc0eebfd feat(tribe-P4d): cap swimmy-data-keeper memory with cgroup MemoryMax=3G
e2677f29 feat(tribe-P4c): centralize SBCL heap to /etc/swimmy/heap.env, split var names
f7b2d57b feat(tribe-P4a): harden brain/school crash-loop discipline + OnFailure alert
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
